### PR TITLE
chore: add Zenodo metadata needed for archiving repo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,51 @@
+{
+    "title": "Substitution of red meat with legumes and risk of primary liver cancer in UK Biobank participants: A prospective cohort study",
+    "upload_type": "other",
+    "creators": [
+        {
+            "affiliation": "Department of Public Health, Aarhus University, Aarhus, Denmark",
+            "name": "Niels Bock",
+            "orcid": "0009-0005-7373-1589"
+        },
+        {
+            "affiliation": "Department of Public Health, Aarhus University, Aarhus, Denmark",
+            "name": "Fie Langmann",
+            "orcid": "0000-0003-3474-9346"
+        },
+        {
+            "affiliation": "Steno Diabetes Center Aarhus, Aarhus, Denmark",
+            "name": "Luke W. Johnston",
+            "orcid": "0000-0003-4169-2616"
+        },
+        {
+            "affiliation": "Department of Public Health, Aarhus University, Aarhus, Denmark",
+            "name": "Daniel B. Ibsen",
+            "orcid": "0000-0002-7038-4770"
+        },
+        {
+            "affiliation": "Department of Public Health, Aarhus University, Aarhus, Denmark",
+            "name": "Christina C. Dahm",
+            "orcid": "0000-0003-0481-2893"
+        }
+    ],
+    "access_right": "open",
+    "description": "With this project, we will statistically model replacement of red meat consumption with legumes in relation to incident primary liver cancer and assess whether the association is mediated through non-alcoholic fatty liver disease (NAFLD). This research project uses the UK Biobank Resource under Application Number 81520.",
+    "keywords": [
+        "nutritional science",
+        "nutritional epidemiology",
+        "cancer research",
+        "epidemiology",
+        "ukbiobank",
+        "data analysis",
+        "reproducible research",
+        "reproducibility",
+        "open science"
+    ],
+    "related_identifiers": [
+        {
+          "relation": "isSourceOf",
+          "identifier": "https://github.com/steno-aarhus/legliv"
+        }
+    ],
+    "license": "mit"
+}


### PR DESCRIPTION
This file is used whenever a GitHub tag and release is created, to automatically create a version on Zenodo. I'll merge it in, this is so you see what I've done to the repo.